### PR TITLE
removeAll() fix

### DIFF
--- a/src/enderalgameplugins.cpp
+++ b/src/enderalgameplugins.cpp
@@ -68,7 +68,8 @@ QStringList EnderalGamePlugins::readPluginList(MOBase::IPluginList *pluginList)
     }
 
     // Do not sort the primary plugins. Their load order should be locked as defined in "primaryPlugins".
-    for (QString plugin : plugins) {
+    const QStringList pluginsClone(plugins);
+    for (QString plugin : pluginsClone) {
         if (primaryPlugins.contains(plugin, Qt::CaseInsensitive))
             plugins.removeAll(plugin);
     }


### PR DESCRIPTION
- `removeAll()` was called inside a loop over the same list, which could leave primary plugins in the list
- This bug could end up disabling some primary plugins, but only if "force-enable game files" was not active.
- Note that gamebryo was fixed in https://github.com/ModOrganizer2/modorganizer-game_gamebryo/commit/805a185900b3f2aa509d34d91860a1f1fc1229dc, but skyrim LE, enderal and morrowind were still broken
