### PR TITLE
Do not create loadorder.txt when initializing profile

### DIFF
--- a/src/gameenderal.cpp
+++ b/src/gameenderal.cpp
@@ -119,7 +119,6 @@ void GameEnderal::initializeProfile(const QDir &path, ProfileSettings settings) 
 {
   if (settings.testFlag(IPluginGame::MODS)) {
     copyToProfile(localAppFolder() + "/enderal", path, "plugins.txt");
-    copyToProfile(localAppFolder() + "/enderal", path, "loadorder.txt");
   }
 
   if (settings.testFlag(IPluginGame::CONFIGURATION)) {
@@ -283,4 +282,3 @@ QString GameEnderal::identifyGamePath() const
   }
   return result;
 }
-

--- a/src/gameenderal.cpp
+++ b/src/gameenderal.cpp
@@ -105,7 +105,7 @@ QString GameEnderal::description() const
 
 MOBase::VersionInfo GameEnderal::version() const
 {
-  return VersionInfo(1, 2, 0, VersionInfo::RELEASE_FINAL);
+  return VersionInfo(1, 3, 0, VersionInfo::RELEASE_FINAL);
 }
 
 QList<PluginSetting> GameEnderal::settings() const


### PR DESCRIPTION
The original intention behind loadorder.txt is to simply report the
load order of plugins to other applications. If the file is not a
known, good load order from MO2, it should not be used to change
the load order.